### PR TITLE
Cast user input to int

### DIFF
--- a/lib/workbench.py
+++ b/lib/workbench.py
@@ -22,7 +22,7 @@ def get_domain(company): #Clearbit API - clearbit.com
 			print "Multiple domains identified for company. Which one is the target?"
 			for index, result in enumerate(clearbit_results):
 				print "{}) Name: {}, Domain: {}".format(index, result["name"], result["domain"])
-			choice = input()
+			choice = int(input())
 			domain = clearbit_results[choice]["domain"]
 
 	if domain:


### PR DESCRIPTION
The user's input is used as a list index, which must be an `int` and not a `string`. This value must be cast to be used.